### PR TITLE
Don't build SDL 1.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/io.openrct2.OpenRCT2.yaml
+++ b/io.openrct2.OpenRCT2.yaml
@@ -22,8 +22,7 @@ finish-args:
   # OpenGL access
   - --device=dri
 modules:
-  - shared-modules/SDL/SDL-1.2.15.json
-  - shared-modules/SDL/SDL_ttf-2.0.11.json
+  # Freedesktop 19.08 runtime already contains SDL 2, so it's not built here
 
   - name: libzip
     buildsystem: cmake


### PR DESCRIPTION
It turns out this wasn't used anyway, because the runtime already contains SDL 2.