### PR TITLE
Add workflow for changing beta commit

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -21,4 +21,4 @@ jobs:
           git config user.name "Workflow trigger"
           git add openrct2-git.yml
           git commit -m "Update to commit ${{ github.event.client_payload.commit }}"
-          git push https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}
+          git push

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -18,8 +18,8 @@ jobs:
           sed -ri 's/^commit:\s.+$/commit: ${{ github.event.client_payload.commit }}/' openrct2-git.yml
       - name: Push change to beta branch
         run: |
-          git config user.email github-actions@github.com
-          git config user.name github-actions
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name "Workflow trigger"
           git add openrct2-git.yml
           git commit -m "Update to commit ${{ github.event.client_payload.commit }}"
           git push

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -17,8 +17,8 @@ jobs:
           sed -ri 's/^commit:\s.+$/commit: ${{ github.event.client_payload.commit }}/' openrct2-git.yml
       - name: Push change to beta branch
         run: |
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git config user.name "Workflow trigger"
+          git config user.email github-actions@github.com
+          git config user.name github-actions
           git add openrct2-git.yml
           git commit -m "Update to commit ${{ github.event.client_payload.commit }}"
           git push

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Push change to beta branch
         run: |
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git config user.name "Workflow trigger"
+          git config user.name "OpenRCT2 develop push trigger"
           git add openrct2-git.yml
           git commit -m "Update to commit ${{ github.event.client_payload.commit }}"
           git push

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,24 @@
+name: OpenRCT2 develop build CI
+
+on:
+  repository_dispatch:
+    types: ["openrct2_develop_push"]
+
+jobs:
+  change-commit:
+    name: Change commit to latest upstream OpenRCT2 develop commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: beta
+      - name: Change commit
+        run: |
+          sed -ri 's/^commit:\s.+$/commit: ${{ github.event.client_payload.commit }}/' openrct2-git.yml
+      - name: Push change to beta branch
+        run: |
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name "Workflow trigger"
+          git add openrct2-git.yml
+          git commit -m "Update to commit ${{ github.event.client_payload.commit }}"
+          git push https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   change-commit:
     name: Change commit to latest upstream OpenRCT2 develop commit
+    if: github.event.client_payload.commit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The workflow will listen for a `repository_dispatch` of type `openrct2_develop_push` and change the source commit of the manifest in the beta branch.

Discussed in #4.

See https://github.com/OpenRCT2/OpenRCT2/pull/12836 for the upstream PR.