### PR TITLE
Add RCT and RCT2 Steam installation paths to filesystem permissions

### DIFF
--- a/io.openrct2.OpenRCT2.yaml
+++ b/io.openrct2.OpenRCT2.yaml
@@ -22,6 +22,9 @@ finish-args:
   - --device=dri
   # Discord RPC
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  # Access to host Steam-installed RCT and RCT2 for auto-detection in OpenRCT2
+  - --filesystem=~/.local/share/Steam/steamapps/common/Rollercoaster Tycoon Deluxe:ro
+  - --filesystem=~/.local/share/Steam/steamapps/common/Rollercoaster Tycoon 2:ro
 
 modules:
 


### PR DESCRIPTION
OpenRCT2 needs access to host Steam-installed RollerCoaster Tycoon and RollerCoaster Tycoon 2 directories for automatic asset loading, mostly useful for Steam Deck users.