### PR TITLE
update deprecated boost url

### DIFF
--- a/io.openrct2.OpenRCT2.yaml
+++ b/io.openrct2.OpenRCT2.yaml
@@ -50,13 +50,13 @@ modules:
           - ./b2 -j$FLATPAK_BUILDER_N_JOBS install variant=release cxxstd=17 --layout=system
         sources:
           - type: archive
-            url: https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2
+            url: https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2
             sha256: 1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b
             x-checker-data:
               type: html
               url: https://www.boost.org/feed/downloads.rss
               version-pattern: <link>https://www.boost.org/users/history/version_([\d_]+).html</link>
-              url-template: https://boostorg.jfrog.io/artifactory/main/release/$version0.$version2.$version4/source/boost_$version.tar.bz2
+              url-template: https://archives.boost.io/release/$version0.$version2.$version4/source/boost_$version.tar.bz2
 
   - name: OpenRCT2
     buildsystem: cmake-ninja


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
