### PR TITLE
Fix RCT Deluxe path detection

### DIFF
--- a/io.openrct2.OpenRCT2.yaml
+++ b/io.openrct2.OpenRCT2.yaml
@@ -24,7 +24,7 @@ finish-args:
   # Discord RPC
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   # Access to host Steam-installed RCT and RCT2 for auto-detection in OpenRCT2
-  - --filesystem=~/.local/share/Steam/steamapps/common/Rollercoaster Tycoon Deluxe:ro
+  - --filesystem=~/.local/share/Steam/steamapps/common/RollerCoaster Tycoon Deluxe:ro
   - --filesystem=~/.local/share/Steam/steamapps/common/Rollercoaster Tycoon 2:ro
   - --filesystem=~/.local/share/Steam/steamapps/common/RollerCoaster Tycoon Classic:ro
 


### PR DESCRIPTION
Paths are case-sensitive.

The other two are fine.

Info taken from my personal install and also https://steamdb.info/app/285310/config/, https://steamdb.info/app/683900/config/ and https://steamdb.info/app/285330/config/.