### PR TITLE
Override SDL window WMClass with app ID

### DIFF
--- a/openrct2-wrapper
+++ b/openrct2-wrapper
@@ -5,4 +5,4 @@ for i in {0..9}; do
     test -S "$XDG_RUNTIME_DIR"/discord-ipc-"$i" || ln -sf {app/com.discordapp.Discord,"$XDG_RUNTIME_DIR"}/discord-ipc-"$i";
 done
 
-exec /app/bin/openrct2-wrapped "$@"
+env SDL_VIDEO_WAYLAND_WMCLASS=io.openrct2.OpenRCT2 SDL_VIDEO_X11_WMCLASS=io.openrct2.OpenRCT2 /app/bin/openrct2-wrapped "$@"


### PR DESCRIPTION
Under KDE, probably because we change the desktop file to `io.openrct2.OpenRCT2`, the OpenRCT2 window is not associated with its icon, resulting in the default Wayland icon and a loading cursor even when the game has launched. To fix this, we can use the `SDL_VIDEO_[WAYLAND,X11]_WMCLASS` environment variables in order to override the WMClass to the application ID.

Fixes #125.